### PR TITLE
Duplicating color_ramp and curve on creation so that user doesn't change the default resource by accident

### DIFF
--- a/GPUTrail3D.gd
+++ b/GPUTrail3D.gd
@@ -96,8 +96,8 @@ func _ready():
 		draw_pass_1.material = ShaderMaterial.new()
 		draw_pass_1.material.shader = preload("shaders/trail_draw_pass.gdshader")
 
-		color_ramp = preload(_DEFAULT_TEXTURE)
-		curve = preload(_DEFAULT_CURVE)
+		color_ramp = preload(_DEFAULT_TEXTURE).duplicate(true)
+		curve = preload(_DEFAULT_CURVE).duplicate(true)
 		
 		draw_pass_1.material.resource_local_to_scene = true
 	


### PR DESCRIPTION
On creation, GPUTrail already fills the color_ramp and curve with the default resources. However, it keeps a reference to the original resource instead of creating a new one for the new node. This means that, unless the user changes those resources manually by marking them as unique or assigning a new one, the default resource will be changed which might impact other instances of that node unintentionally