### PR TITLE
Added Active control, fade controls, alpha control, and updated documentation

### DIFF
--- a/GPUTrail3D.gd
+++ b/GPUTrail3D.gd
@@ -64,14 +64,17 @@ class_name GPUTrail3D extends GPUParticles3D
 @export_category("Fade")
 ## Fade Curve is a texture that is used to determine the alpha of the trail over it's lifetime
 @export var fade_curve : CurveTexture : set = _set_fade_curve
+## Fade Curve Intensity is a value used to modify the strength of the Fade Curve
 @export var fade_curve_intensity: float = 1.0 : set = _set_fade_curve_intensity
 
 ## Fade In Seconds is how many seconds it takes to fade in the trail if active is set to true
 @export var fade_in_seconds : float = 0.0 : set = _set_fade_in_seconds
+## Fade In Alpha is the Alpha value that the whole trail will go to. The alpha value is also a parameter on the trail
 @export var fade_in_alpha : float = 1.0 : set = _set_fade_in_alpha
 
-## Fade Away Seconds is how many seconds it takes to fade out the trail if active is set to false
+## Fade Out Seconds is how many seconds it takes to fade out the trail if active is set to false
 @export var fade_out_seconds : float = 0.0 : set = _set_fade_out_seconds
+## Fade Out Alpha is the Alpha value that the whole trail will go to. The alpha value is also a parameter on the trail
 @export var fade_out_alpha : float = 0.0 : set = _set_fade_out_alpha
 
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ GPUTrail is a GPU-based trail plugin for Godot 4, offering an efficient alternat
 - `active`: Turn on or off the trail
 - `length`: Number of steps in the trail
 - `texture`: Main texture of the trail
+- `mask`: A texture used to modify the alpha of trail. Uses the red channel of the texture to determine what is visible.
+- `mask_strength`: A float value from 0.0 to 1.0 for determing how intense the mask texture is
 - `color_ramp`: Color gradient along the trail's length
 - `curve`: Width modulation along the trail's length
 - `vertical_texture`: Adjust texture orientation

--- a/README.md
+++ b/README.md
@@ -25,13 +25,20 @@ GPUTrail is a GPU-based trail plugin for Godot 4, offering an efficient alternat
 3. Attach the `GPUTrail3D` node to the object you want to trail
 
 ## Properties
-
+- `active`: Turn on or off the trail
 - `length`: Number of steps in the trail
 - `texture`: Main texture of the trail
 - `color_ramp`: Color gradient along the trail's length
 - `curve`: Width modulation along the trail's length
 - `vertical_texture`: Adjust texture orientation
 - `use_red_as_alpha`: Use the red channel of the texture as alpha
+- `alpha`: Determines the overall alpha value of the trail. Is modified if using fade in and out parameters
+- `fade_curve`: Curve to control the alpha along the trail's lifetime
+- `fade_curve_intensity`: Value to control the strength of the fade curve value
+- `fade_in_seconds`: Value to determine how quickly the whole trail fades in if active is set from false to true
+- `fade_in_alpha`: Value to determine what alpha value the whole trail fades to if active is set from false to true
+- `fade_out_seconds`: Value to determine how quickly the whole trail fades out if active is set from true to false
+- `fade_out_alpha`: Value to determine what alpha value the whole trail fades to if active is set from true to false
 - `billboard`: Make the trail face the camera (experimental)
 - `dewiggle`: Improve texture mapping to the trail
 - `clip_overlaps`: Prevent trail self-intersectionis

--- a/shaders/trail.gdshader
+++ b/shaders/trail.gdshader
@@ -5,11 +5,7 @@ render_mode keep_data,disable_force,disable_velocity;
 uniform bool active = true;
 
 void process() {
-	if(active) {
-		ACTIVE = true;
-	} else {
-		ACTIVE = false;
-	}
+	ACTIVE = active;
 
 	// CUSTOM.w tracks the particles place in the trail, in range (0..LIFETIME]
 	// requires that LIFETIME = number of particles

--- a/shaders/trail.gdshader
+++ b/shaders/trail.gdshader
@@ -2,37 +2,43 @@ shader_type particles;
 
 render_mode keep_data,disable_force,disable_velocity;
 
-
+uniform bool active = true;
 
 void process() {
+	if(active) {
+		ACTIVE = true;
+	} else {
+		ACTIVE = false;
+	}
+
 	// CUSTOM.w tracks the particles place in the trail, in range (0..LIFETIME]
 	// requires that LIFETIME = number of particles
 	float amount = LIFETIME;
-	
+
 	vec4 a = EMISSION_TRANSFORM * vec4(0,1,0,1);
 	vec4 b = EMISSION_TRANSFORM * vec4(0,-1,0,1);
-	
+
 	// start
 	if(CUSTOM.w == 0.0){
 		CUSTOM.w = float(INDEX)+1.0;
-		
+
 		// needed to pass to draw pass
 		CUSTOM.z = amount;
-		
+
 		// needed to initialize in case of CUSTOM.w == 2.0
 		TRANSFORM = mat4(a,a,b,b);
 	}
-	
+
 	// restart
 	if(CUSTOM.w == amount+1.0){
 		CUSTOM.w = 1.0;
 	}
-	
+
 	if(CUSTOM.w == 1.0){
 		// sets the quad to the line to cache this frame, it is not yet visible
 		TRANSFORM = mat4(a,a,b,b);
 	}
-	
+
 	if(CUSTOM.w == 2.0){
 		// sets the right edge of the quad
 		TRANSFORM[1] = a;

--- a/shaders/trail_draw_pass.gdshader
+++ b/shaders/trail_draw_pass.gdshader
@@ -5,6 +5,9 @@ render_mode unshaded,world_vertex_coords,cull_disabled;
 uniform sampler2D tex : repeat_enable, source_color, hint_default_white;
 uniform sampler2D mask : hint_default_white;
 uniform float mask_strength = 1.0;
+uniform sampler2D fade_curve: repeat_disable, hint_default_black;
+uniform float fade_curve_intensity = 1.0;
+uniform float alpha = 1.0;
 uniform vec2 uv_offset = vec2(0);
 uniform sampler2D color_ramp : repeat_disable, source_color, hint_default_white;
 uniform sampler2D curve : repeat_disable, hint_default_white;
@@ -27,6 +30,7 @@ uniform bool snap_to_transform = false;*/
 varying float scale_interp;
 varying vec2 clip;
 varying vec2 mesh_uv;
+varying float particle_lifetime;
 void vertex(){
 	mesh_uv = UV;
 
@@ -76,6 +80,7 @@ void vertex(){
 		UV *= scale_interp;
 	}
 
+	particle_lifetime = INSTANCE_CUSTOM.y;
 
 	clip.x = dot(VERTEX - INV_VIEW_MATRIX[3].xyz,cross(my_model_matrix[1].xyz - INV_VIEW_MATRIX[3].xyz,my_model_matrix[2].xyz - INV_VIEW_MATRIX[3].xyz));
 	clip.y = dot(VERTEX - INV_VIEW_MATRIX[3].xyz,cross(my_model_matrix[3].xyz - INV_VIEW_MATRIX[3].xyz,my_model_matrix[0].xyz - INV_VIEW_MATRIX[3].xyz));
@@ -120,16 +125,22 @@ void fragment(){
 		ALPHA = T.r;
 	}
 
+	vec4 F = textureLod(fade_curve, raw_uv, 0.0);
+	float fade_alpha = F.x * (fade_curve_intensity - (particle_lifetime * fade_curve_intensity));
+	ALPHA *= fade_alpha;
+
 	T = textureLod(color_ramp, raw_uv, 0.0);
+	float texture_alpha = T.a;
 	ALBEDO *= T.rgb;
-	ALPHA *= T.a;
+	ALPHA *= texture_alpha;
 
-	vec4 M = textureLod(mask, base_uv, 0.0);
-	ALPHA *= (M.r * mask_strength);
-
-	//ALBEDO = vec3(UV,0);
+	vec4 M = textureLod(mask, raw_uv, 0.0);
+	float mask_alpha = (M.r * mask_strength);
+	ALPHA *= mask_alpha;
 
 	if((base_uv.x < .01) || (.99 < base_uv.x)){
 		//ALBEDO = vec3(1,0,1);
 	}
+
+	ALPHA *= alpha;
 }

--- a/shaders/trail_draw_pass.gdshader
+++ b/shaders/trail_draw_pass.gdshader
@@ -5,7 +5,7 @@ render_mode unshaded,world_vertex_coords,cull_disabled;
 uniform sampler2D tex : repeat_enable, source_color, hint_default_white;
 uniform sampler2D mask : hint_default_white;
 uniform float mask_strength = 1.0;
-uniform sampler2D fade_curve: repeat_disable, hint_default_black;
+uniform sampler2D fade_curve: repeat_disable, hint_default_white;
 uniform float fade_curve_intensity = 1.0;
 uniform float alpha = 1.0;
 uniform vec2 uv_offset = vec2(0);


### PR DESCRIPTION
This PR adds:

- The ability to activate and deactivate a trail
- The ability to control the whole trail alpha via single parameter
- The ability to trigger the the whole trail to fade in or out based on time when activated or deactivated
- The ability to fade out the trail based on each individual trail particle lifetime
- Updated documentation describing the above parameters added as well as missing mask and mask_strength properties

<img width="389" height="1264" alt="image" src="https://github.com/user-attachments/assets/004b0ffe-c5dd-47f4-ad16-05a78f23747c" />

